### PR TITLE
docs: use tfvars example

### DIFF
--- a/hacks/genai-monitoring/artifacts/.gitignore
+++ b/hacks/genai-monitoring/artifacts/.gitignore
@@ -1,0 +1,1 @@
+terraform.tfvars

--- a/hacks/genai-monitoring/artifacts/README.md
+++ b/hacks/genai-monitoring/artifacts/README.md
@@ -64,7 +64,7 @@ The primary goals of this Terraform code are to:
     * Genkit CLI installed.
 
 2.  **Configuration:**
-    *   Update `variables.tf` with your project ID or pass them in as command-line arguments.
+    *   Copy `terraform.tfvars.example` to `terraform.tfvars` and provide configuration or pass variables in as command-line arguments.
 
 3.  **Deployment:**
     *   Run `terraform init` to initialize the Terraform working directory.

--- a/hacks/genai-monitoring/artifacts/terraform.tfvars.example
+++ b/hacks/genai-monitoring/artifacts/terraform.tfvars.example
@@ -1,0 +1,2 @@
+# Add your Google Cloud project ID below
+gcp_project_id = ""


### PR DESCRIPTION
Suggestion to use a tfvars file to discourage editing source controlled files for each deploy